### PR TITLE
Fix forbidden syntax

### DIFF
--- a/aip_x1_description/urdf/sensor_kit.xacro
+++ b/aip_x1_description/urdf/sensor_kit.xacro
@@ -18,9 +18,9 @@
     <!-- sensor -->
     <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
     <!-- lidar -->
-    <VLP-16 parent="sensor_kit_base_link" name="velodyne_top" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">
+    <xacro:VLP-16 parent="sensor_kit_base_link" name="velodyne_top" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">
       <origin xyz="${calibration['sensor_kit_base_link2velodyne_top_base_link']['x']} ${calibration['sensor_kit_base_link2velodyne_top_base_link']['y']} ${calibration['sensor_kit_base_link2velodyne_top_base_link']['z']}" rpy="${calibration['sensor_kit_base_link2velodyne_top_base_link']['roll']} ${calibration['sensor_kit_base_link2velodyne_top_base_link']['pitch']} ${calibration['sensor_kit_base_link2velodyne_top_base_link']['yaw']}" />
-    </VLP-16>
+    </xacro:VLP-16>
     <xacro:include filename="$(find livox_description)/urdf/livox_horizon.xacro"/>
     <xacro:livox_horizon_macro suffix="livox_front_left" parent="sensor_kit_base_link" x="${calibration['sensor_kit_base_link2livox_front_left_base_link']['x']}" y="${calibration['sensor_kit_base_link2livox_front_left_base_link']['y']}" z="${calibration['sensor_kit_base_link2livox_front_left_base_link']['z']}" roll="${calibration['sensor_kit_base_link2livox_front_left_base_link']['roll']}" pitch="${calibration['sensor_kit_base_link2livox_front_left_base_link']['pitch']}" yaw="${calibration['sensor_kit_base_link2livox_front_left_base_link']['yaw']}" />
     <xacro:livox_horizon_macro suffix="livox_front_center" parent="sensor_kit_base_link" x="${calibration['sensor_kit_base_link2livox_front_center_base_link']['x']}" y="${calibration['sensor_kit_base_link2livox_front_center_base_link']['y']}" z="${calibration['sensor_kit_base_link2livox_front_center_base_link']['z']}" roll="${calibration['sensor_kit_base_link2livox_front_center_base_link']['roll']}" pitch="${calibration['sensor_kit_base_link2livox_front_center_base_link']['pitch']}" yaw="${calibration['sensor_kit_base_link2livox_front_center_base_link']['yaw']}" />

--- a/aip_xx1_description/urdf/sensor_kit.xacro
+++ b/aip_xx1_description/urdf/sensor_kit.xacro
@@ -25,15 +25,15 @@
     <!-- sensor -->
     <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
     <!-- lidar -->
-    <VLS-128 parent="sensor_kit_base_link" name="velodyne_top" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">
+    <xacro:VLS-128 parent="sensor_kit_base_link" name="velodyne_top" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">
       <origin xyz="${calibration['sensor_kit_base_link2velodyne_top_base_link']['x']} ${calibration['sensor_kit_base_link2velodyne_top_base_link']['y']} ${calibration['sensor_kit_base_link2velodyne_top_base_link']['z']}" rpy="${calibration['sensor_kit_base_link2velodyne_top_base_link']['roll']} ${calibration['sensor_kit_base_link2velodyne_top_base_link']['pitch']} ${calibration['sensor_kit_base_link2velodyne_top_base_link']['yaw']}" />
-    </VLS-128>
-    <VLP-16 parent="sensor_kit_base_link" name="velodyne_left" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">
+    </xacro:VLS-128>
+    <xacro:VLP-16 parent="sensor_kit_base_link" name="velodyne_left" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">
       <origin xyz="${calibration['sensor_kit_base_link2velodyne_left_base_link']['x']} ${calibration['sensor_kit_base_link2velodyne_left_base_link']['y']} ${calibration['sensor_kit_base_link2velodyne_left_base_link']['z']}" rpy="${calibration['sensor_kit_base_link2velodyne_left_base_link']['roll']} ${calibration['sensor_kit_base_link2velodyne_left_base_link']['pitch']} ${calibration['sensor_kit_base_link2velodyne_left_base_link']['yaw']}" />
-    </VLP-16>
-    <VLP-16 parent="sensor_kit_base_link" name="velodyne_right" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">
+    </xacro:VLP-16>
+    <xacro:VLP-16 parent="sensor_kit_base_link" name="velodyne_right" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">
       <origin xyz="${calibration['sensor_kit_base_link2velodyne_right_base_link']['x']} ${calibration['sensor_kit_base_link2velodyne_right_base_link']['y']} ${calibration['sensor_kit_base_link2velodyne_right_base_link']['z']}" rpy="${calibration['sensor_kit_base_link2velodyne_right_base_link']['roll']} ${calibration['sensor_kit_base_link2velodyne_right_base_link']['pitch']} ${calibration['sensor_kit_base_link2velodyne_right_base_link']['yaw']}" />
-    </VLP-16>
+    </xacro:VLP-16>
     <!-- camera -->
     <xacro:monocular_camera_macro suffix="traffic_light_right_camera/camera" parent="sensor_kit_base_link" namespace="" x="${calibration['sensor_kit_base_link2traffic_light_right_camera']['x']}" y="${calibration['sensor_kit_base_link2traffic_light_right_camera']['y']}" z="${calibration['sensor_kit_base_link2traffic_light_right_camera']['z']}" roll="${calibration['sensor_kit_base_link2traffic_light_right_camera']['roll']}" pitch="${calibration['sensor_kit_base_link2traffic_light_right_camera']['pitch']}" yaw="${calibration['sensor_kit_base_link2traffic_light_right_camera']['yaw']}" fps="30" width="800" height="400" fov="1.3"/>
     <xacro:monocular_camera_macro suffix="traffic_light_left_camera/camera" parent="sensor_kit_base_link" namespace="" x="${calibration['sensor_kit_base_link2traffic_light_left_camera']['x']}" y="${calibration['sensor_kit_base_link2traffic_light_left_camera']['y']}" z="${calibration['sensor_kit_base_link2traffic_light_left_camera']['z']}" roll="${calibration['sensor_kit_base_link2traffic_light_left_camera']['roll']}" pitch="${calibration['sensor_kit_base_link2traffic_light_left_camera']['pitch']}" yaw="${calibration['sensor_kit_base_link2traffic_light_left_camera']['yaw']}" fps="30" width="800" height="400" fov="1.3"/>


### PR DESCRIPTION
Noeticで廃止された記法を修正しました。
挙動としては、エラーもなく動いてくれなくて、何故かstatic tfが出ない、となって悩みました。

```sh
xacro: in-order processing became default in ROS Melodic. You can drop the option.
Deprecated: xacro tag 'VLP-16' w/o 'xacro:' xml namespace prefix (will be forbidden in Noetic)
when processing file: /home/kenji/autoware.proj.eva/install/aip_x1_description/share/aip_x1_description/urdf/sensors.xacro
included from: /home/kenji/autoware.proj.eva/install/vehicle_launch/share/vehicle_launch/urdf/vehicle.xacro
Use the following command to fix incorrect tag usage:
find . -iname "*.xacro" | xargs sed -i 's#<\([/]\?\)\(if\|unless\|include\|arg\|property\|macro\|insert_block\)#<\1xacro:\2#g'
```

以下の動作確認をしています。

- X1

```sh
❯ roslaunch autoware_launch autoware.launch vehicle_model:=ymc_golfcart_proto2 sensor_model:=aip_x1 map_path:=$HOME/Downloads/map/kashiwanoha
❯ rostopic echo /tf_static | grep velodyne
    child_frame_id: "velodyne_top_base_link"
      frame_id: "velodyne_top_base_link"
    child_frame_id: "velodyne_top"
```

- XX1

```sh
❯ roslaunch vehicle_launch vehicle_description.launch vehicle_model:=lexus sensor_model:=aip_xx1 vehicle_id:=default
❯ rostopic echo /tf_static | grep velodyne
    child_frame_id: "velodyne_left_base_link"
      frame_id: "velodyne_left_base_link"
    child_frame_id: "velodyne_left"
    child_frame_id: "velodyne_right_base_link"
      frame_id: "velodyne_right_base_link"
    child_frame_id: "velodyne_right"
    child_frame_id: "velodyne_top_base_link"
      frame_id: "velodyne_top_base_link"
    child_frame_id: "velodyne_top"
```