### PR TITLE
Fix config_dir

### DIFF
--- a/aip_x1_description/urdf/sensor_kit.xacro
+++ b/aip_x1_description/urdf/sensor_kit.xacro
@@ -4,6 +4,7 @@
     <xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro"/>
 
     <xacro:arg name="gpu" default="false"/>
+    <xacro:arg name="config_dir" default="$(find aip_x1_description)/config"/>
     <xacro:property name="sensor_kit_base_link" default="sensor_kit_base_link"/>
 
     <joint name="${sensor_kit_base_link}_joint" type="fixed">

--- a/aip_x1_description/urdf/sensors.xacro
+++ b/aip_x1_description/urdf/sensors.xacro
@@ -2,7 +2,7 @@
 <robot name="vehicle"
   xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:arg name="config_dir" default="$(find aip_x1_description)"/>
+  <xacro:arg name="config_dir" default="$(find aip_x1_description)/config"/>
   <xacro:include filename="$(find aip_x1_description)/urdf/sensor_kit.xacro"/>
   <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
 

--- a/aip_xx1_description/urdf/sensor_kit.xacro
+++ b/aip_xx1_description/urdf/sensor_kit.xacro
@@ -9,7 +9,7 @@
 
     <!-- <xacro:property name="pi" value="3.1415926835897931"/> -->
     <xacro:arg name="gpu" default="false"/>
-    <xacro:arg name="config_dir" default="$(find aip_xx1_description)"/>
+    <xacro:arg name="config_dir" default="$(find aip_xx1_description)/config"/>
 
     <xacro:property name="sensor_kit_base_link" default="sensor_kit_base_link"/>
 


### PR DESCRIPTION
- Fix `config_dir` in xacro files.
- If `config_dir` is defined in the parent, it is not necessary in included childs, but it was added for clarity.
- Tested by `ros2 launch test.launch.xml sensor_model:=aip_xx1`

```
<?xml version="1.0" encoding="UTF-8"?>
<launch>
  <!-- test.launch.xml -->
  <arg name="sensor_model" default="aip_x1"/>
  <arg name="vehicle_model" default="lexus"/>

  <!-- tf publisher -->
  <arg name="model" default="$(find-pkg-share vehicle_launch)/urdf/vehicle.xacro"/>
  <node name="robot_state_publisher" pkg="robot_state_publisher" exec="robot_state_publisher">
    <param name="robot_description" value="$(command 'xacro $(var model) vehicle_model:=$(var vehicle_model) sensor_model:=$(var sensor_model)')"/>
  </node>
</launch>
```