### PR TITLE
fix(pandar_description): malformed color

### DIFF
--- a/pandar_description/urdf/pandar_40p.xacro
+++ b/pandar_description/urdf/pandar_40p.xacro
@@ -14,7 +14,7 @@
         </geometry>
         <origin xyz="0 0 0.011" rpy="0 0 0"/>
         <material name="gray">
-          <color rgba="0.9 0.9 0.9 2.0"/>
+          <color rgba="0.9 0.9 0.9 1.0"/>
         </material>
       </visual>
       <visual>
@@ -23,7 +23,7 @@
         </geometry>
         <origin xyz="0 0 0.047" rpy="0 0 0"/>
         <material name="blue">
-          <color rgba="0.0 0.0 1.0 2.0"/>
+          <color rgba="0.0 0.0 1.0 1.0"/>
         </material>
       </visual>
       <visual>

--- a/pandar_description/urdf/pandar_qt.xacro
+++ b/pandar_description/urdf/pandar_qt.xacro
@@ -14,7 +14,7 @@
         </geometry>
         <origin xyz="0 0 0.010" rpy="0 0 0"/>
         <material name="gray">
-          <color rgba="0.9 0.9 0.9 2.0"/>
+          <color rgba="0.9 0.9 0.9 1.0"/>
         </material>
       </visual>
       <visual>
@@ -23,7 +23,7 @@
         </geometry>
         <origin xyz="0 0 0.043" rpy="0 0 0"/>
         <material name="blue">
-          <color rgba="0.0 0.0 1.0 2.0"/>
+          <color rgba="0.0 0.0 1.0 1.0"/>
         </material>
       </visual>
       <visual>


### PR DESCRIPTION
## Description
- Xacro files in pandar_description have malformed color rgba values and the following error are output.
```
[rviz2-58] Error:   Material [gray] has malformed color rgba values: Unable to parse component [2.0] to a double (while parsing a color value)
[rviz2-58]          at line 90 in /tmp/binarydeb/ros-galactic-urdfdom-2.3.5/urdf_parser/src/link.cpp
[rviz2-58] Error:   Material [blue] has malformed color rgba values: Unable to parse component [2.0] to a double (while parsing a color value)
[rviz2-58]          at line 90 in /tmp/binarydeb/ros-galactic-urdfdom-2.3.5/urdf_parser/src/link.cpp
````
- This PR fixes the malformed color values