### PR TITLE
fix(pandar_description): color(alpha)

### DIFF
--- a/pandar_description/urdf/pandar_xt32.xacro
+++ b/pandar_description/urdf/pandar_xt32.xacro
@@ -14,7 +14,7 @@
         </geometry>
         <origin xyz="0 0 0.010" rpy="0 0 0"/>
         <material name="gray">
-          <color rgba="0.9 0.9 0.9 2.0"/>
+          <color rgba="0.9 0.9 0.9 1.0"/>
         </material>
       </visual>
       <visual>
@@ -23,7 +23,7 @@
         </geometry>
         <origin xyz="0 0 0.043" rpy="0 0 0"/>
         <material name="blue">
-          <color rgba="0.0 0.0 1.0 2.0"/>
+          <color rgba="0.0 0.0 1.0 1.0"/>
         </material>
       </visual>
       <visual>


### PR DESCRIPTION
Fix wrong alpha value.

```
[robot_state_publisher-1] Error:   Material [gray] has malformed color rgba values: Unable to parse component [2.0] to a double (while parsing a color value)
```