### PR TITLE
feat: radar description

### DIFF
--- a/radar_description/CMakeLists.txt
+++ b/radar_description/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(radar_description)
+
+find_package(ament_cmake_auto REQUIRED)
+
+ament_auto_find_build_dependencies()
+
+ament_auto_package(INSTALL_TO_SHARE
+  urdf
+)

--- a/radar_description/package.xml
+++ b/radar_description/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>radar_description</name>
+  <version>0.1.0</version>
+  <description>The radar_description package</description>
+
+  <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
+  <license>Apache2</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/radar_description/urdf/radar.xacro
+++ b/radar_description/urdf/radar.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="radar_macro" params="name parent x y z roll pitch yaw">
-    <xacro:property name="mass" value="0.01" />
+    <xacro:property name="mass" value="0.01"/>
 
     <joint name="${name}_base_mount_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${x} ${y} ${z}"/>
       <parent link="${parent}"/>
-      <child  link="${name}_base_link"/>
+      <child link="${name}_base_link"/>
     </joint>
 
     <link name="${name}_base_link">
@@ -22,9 +22,7 @@
       <inertial>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <mass value="${mass}"/>
-        <inertia ixx="${(0.03*0.03+0.03*0.03)*mass/12.0}" ixy="0.0" ixz="0.0"
-                 iyy="${(0.1*0.1+0.1*0.1)*mass/12.0}" iyz="0.0"
-                 izz="${(0.1*0.1+0.1*0.1)*mass/12.0}"/>
+        <inertia ixx="${(0.03*0.03+0.03*0.03)*mass/12.0}" ixy="0.0" ixz="0.0" iyy="${(0.1*0.1+0.1*0.1)*mass/12.0}" iyz="0.0" izz="${(0.1*0.1+0.1*0.1)*mass/12.0}"/>
       </inertial>
     </link>
   </xacro:macro>

--- a/radar_description/urdf/radar.xacro
+++ b/radar_description/urdf/radar.xacro
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="radar_macro" params="name parent x y z roll pitch yaw">
+    <xacro:property name="mass" value="0.01" />
+
+    <joint name="${name}_base_mount_joint" type="fixed">
+      <origin rpy="${roll} ${pitch} ${yaw}" xyz="${x} ${y} ${z}"/>
+      <parent link="${parent}"/>
+      <child  link="${name}_base_link"/>
+    </joint>
+
+    <link name="${name}_base_link">
+      <visual>
+        <geometry>
+          <box size="0.03 0.1 0.1"/>
+        </geometry>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <material name="red">
+          <color rgba="0.1 0.1 0.1 1.0"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="${mass}"/>
+        <inertia ixx="${(0.03*0.03+0.03*0.03)*mass/12.0}" ixy="0.0" ixz="0.0"
+                 iyy="${(0.1*0.1+0.1*0.1)*mass/12.0}" iyz="0.0"
+                 izz="${(0.1*0.1+0.1*0.1)*mass/12.0}"/>
+      </inertial>
+    </link>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
Everywhere radar xacro is defined separately. Added radar_description as a common sensor.
I plan to discontinue radar.xacro in the following packages in the future.

- https://github.com/tier4/aip_launcher/blob/tier4/universe/aip_xx1_description/urdf/radar.xacro
- https://github.com/tier4/aip_launcher/blob/tier4/universe/aip_x2_description/urdf/radar.xacro